### PR TITLE
Use a Map instead of an object to get unique mappings for boot entries

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -18,7 +18,7 @@ export default class RestartTo extends Extension {
         if (!proc.get_successful()) {
             throw new Error("Failed to get boot entries");
         }
-        return {...[...stdout.matchAll(/Boot([0-9]{4})\* ([^\t]*)/g)].map(m => (m[1], m[2]))};
+        return new Map([...stdout.matchAll(/Boot([0-9]{4})\* ([^\t]*)/g)].map(m => [m[1], m[2]])).entries();
     }
 
     async restartTo(id) {
@@ -46,7 +46,7 @@ export default class RestartTo extends Extension {
     addMenuItem() {
         this.menuItem = new PopupMenu.PopupSubMenuMenuItem('Restart To...', false);
         this.getBootEntries().then((bootEntries) => {
-            for (const [id, name] of Object.entries(bootEntries)) {
+            for (const [id, name] of bootEntries) {
                 this.menuItem.menu.addAction(name, () => {
                     this.restartTo(id);
                 });

--- a/extension.js
+++ b/extension.js
@@ -18,7 +18,7 @@ export default class RestartTo extends Extension {
         if (!proc.get_successful()) {
             throw new Error("Failed to get boot entries");
         }
-        return new Map([...stdout.matchAll(/Boot([0-9]{4})\* ([^\t]*)/g)].map(m => [m[1], m[2]])).entries();
+        return new Map([...stdout.matchAll(/Boot([0-9]{4})\* ([^\t]*)/g)].map(m => [m[1], m[2]]));
     }
 
     async restartTo(id) {
@@ -46,7 +46,7 @@ export default class RestartTo extends Extension {
     addMenuItem() {
         this.menuItem = new PopupMenu.PopupSubMenuMenuItem('Restart To...', false);
         this.getBootEntries().then((bootEntries) => {
-            for (const [id, name] of bootEntries) {
+            for (const [id, name] of bootEntries.entries()) {
                 this.menuItem.menu.addAction(name, () => {
                     this.restartTo(id);
                 });


### PR DESCRIPTION
At the moment the efimanager command sets boot next to the index of the boot entry in the command output, as the array (with integer keys) gets spread into the object. Also Maps are the intended way to store unique key value pairs in JS (afaik).