### PR TITLE
Add space between Restart to and the three dots following in the translation.

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -18,5 +18,5 @@ msgstr ""
 "X-Generator: Poedit 3.5\n"
 
 #: extension.js:47
-msgid "Restart To..."
+msgid "Restart To ..."
 msgstr "Neustart zu ..."

--- a/po/hu.po
+++ b/po/hu.po
@@ -18,5 +18,5 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: extension.js:47
-msgid "Restart To..."
-msgstr "Újraindítás..."
+msgid "Restart To ..."
+msgstr "Újraindítás ..."

--- a/po/pt.po
+++ b/po/pt.po
@@ -17,5 +17,5 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: extension.js:47
-msgid "Restart To..."
-msgstr "Reiniciar para..."
+msgid "Restart To ..."
+msgstr "Reiniciar para ..."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -17,6 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: extension.js:47
-msgid "Restart To..."
-msgstr "Reiniciar para..."
+msgid "Restart To ..."
+msgstr "Reiniciar para ..."
 


### PR DESCRIPTION
Add space between Restart to and the three dots following in the pot and po files because that is how it looks in gnome-shell-0.47 for all other entries with 3 dots.