### PR TITLE
Fix "TypeError: this.settings is undefined" (https://github.com/tiago…

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -67,6 +67,8 @@ export default class RestartTo extends Extension {
     }
 
     enable() {
+        this.settings = this.getSettings();
+
         this.proxy = Gio.DBusProxy.makeProxyWrapper(`<node>
           <interface name="org.freedesktop.login1.Manager">
             <method name="SetRebootToFirmwareSetup">
@@ -90,7 +92,6 @@ export default class RestartTo extends Extension {
             this.addMenuItem();
         }
 
-        this.settings = this.getSettings('org.gnome.shell.extensions.restartto');
         this.settings.connect('changed::blacklist', (settings, key) => {
             this.updateMenuEntries()
         });


### PR DESCRIPTION
I moved the `this.settings` to the top of the enable function, as the function `addMenuItem()`, relies on this.settings being defined.

The problem is that addMenuItem is called before this.settings is defined, therefore causing the error.