### PR TITLE
Extension Overhaul: rename, reorder, whitelist mode, and full keyboard navigation

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,6 +6,7 @@ import Gio from 'gi://Gio';
 import {Extension, gettext as _} from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import {getBootEntries} from './efi.js';
+import {migrateSettings} from './settingsmigration.js';
 
 Gio._promisify(Gio.Subprocess.prototype, 'communicate_utf8_async');
 Gio._promisify(Gio.Subprocess.prototype, 'wait_async');
@@ -36,24 +37,53 @@ export default class RestartTo extends Extension {
     updateMenuEntries() {
         if (this.menuItem == null)
             return;
-        const blacklist = this.settings.get_strv('blacklist');
-        this.menuItem.menu.removeAll();
-        if (!blacklist.includes('UEFI')) {
-            this.menuItem.menu.addAction('UEFI', async () => {
-                this.proxy.SetRebootToFirmwareSetupRemote(true);
-                try {
-                    await new GnomeSession.SessionManager().RebootAsync();
-                } catch (e) {
-                    console.warn(e);
-                    this.proxy?.SetRebootToFirmwareSetupRemote(false);
-                }
-            });
+        const hiddenEntries = this.settings.get_strv('hidden-entries');
+        const savedOrder = this.settings.get_strv('order');
+        
+        let customNames = {};
+        try {
+            customNames = JSON.parse(this.settings.get_string('custom-names') || '{}');
+        } catch (e) {
+            customNames = {};
         }
+
+        this.menuItem.menu.removeAll();
+
         getBootEntries().then((bootEntries) => {
+            // Compile unified structural array
+            const items = [{ id: 'UEFI', defaultName: 'UEFI' }];
             for (const [id, name] of bootEntries.entries()) {
-                if (!blacklist.includes(name)) {
-                    this.menuItem.menu.addAction(name, () => {
-                        this.restartTo(id);
+                items.push({ id: id, defaultName: name });
+            }
+
+            // Sort array matching preferences layout order configuration
+            items.sort((a, b) => {
+                let idxA = savedOrder.indexOf(a.id);
+                let idxB = savedOrder.indexOf(b.id);
+                if (idxA === -1) idxA = 999;
+                if (idxB === -1) idxB = 999;
+                return idxA - idxB;
+            });
+
+            // Build menu list matching custom arrangement specifications
+            for (const item of items) {
+                if (hiddenEntries.includes(item.id)) continue;
+
+                const displayName = customNames[item.id] || item.defaultName;
+
+                if (item.id === 'UEFI') {
+                    this.menuItem.menu.addAction(displayName, async () => {
+                        this.proxy.SetRebootToFirmwareSetupRemote(true);
+                        try {
+                            await new GnomeSession.SessionManager().RebootAsync();
+                        } catch (e) {
+                            console.warn(e);
+                            this.proxy?.SetRebootToFirmwareSetupRemote(false);
+                        }
+                    });
+                } else {
+                    this.menuItem.menu.addAction(displayName, () => {
+                        this.restartTo(item.id);
                     });
                 }
             }
@@ -68,6 +98,9 @@ export default class RestartTo extends Extension {
 
     enable() {
         this.settings = this.getSettings();
+        
+        // Run settings Migration (background task)
+        migrateSettings(this.settings).catch(console.error);
 
         this.proxy = Gio.DBusProxy.makeProxyWrapper(`<node>
           <interface name="org.freedesktop.login1.Manager">
@@ -92,12 +125,18 @@ export default class RestartTo extends Extension {
             this.addMenuItem();
         }
 
-        this.settings.connect('changed::blacklist', (settings, key) => {
-            this.updateMenuEntries()
-        });
+        this._hiddenSignal = this.settings.connect('changed::hidden-entries', () => this.updateMenuEntries());
+        this._customSignal = this.settings.connect('changed::custom-names', () => this.updateMenuEntries());
+        this._orderSignal = this.settings.connect('changed::order', () => this.updateMenuEntries());
     }
 
     disable() {
+        if (this.settings) {
+            this.settings.disconnect(this._hiddenSignal);
+            this.settings.disconnect(this._customSignal);
+            this.settings.disconnect(this._orderSignal);
+            this.settings = null;
+        }
         this.proxy = null;
         this.menuItem.destroy();
         this.menuItem = null;

--- a/po/cs_CZ.po
+++ b/po/cs_CZ.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the restartto@tiagoporsch.github.io package.
 # Jiří Švácha <jiri@jirkasvacha.cz>, 2025.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -18,18 +17,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
 
-#: extension.js:64
+#: extension.js:94
 msgid "Restart To..."
 msgstr "Restartovat do..."
 
-#: prefs.js:13
+#: prefs.js:16
 msgid "General"
 msgstr "Obecné"
 
-#: prefs.js:19
-msgid "Blacklist"
-msgstr "Blacklist"
+#: prefs.js:22
+msgid "Select Boot Entries to display"
+msgstr "Vyberte položky spouštění k zobrazení"
 
-#: prefs.js:20
-msgid "Hide boot entries"
-msgstr "Skrýt položky v bootovací nabídce"
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr "Kliknutím skryjete/zobrazíte. Tažením změníte pořadí. Kliknutím na název jej přejmenujete."
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr "Klávesové zkratky"
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+"<b>J / K</b> : Posunout vybraný řádek dolů / nahoru\n"
+"<b>Mezerník / Enter</b> : Přepnout viditelnost\n"
+"<b>R / E / F2</b> : Přejmenovat položku\n"
+"<b>Esc</b> : Zrušit úpravy"
+
+#: prefs.js:48
+msgid "Understood"
+msgstr "Rozumím"
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr "Kliknutím přejmenujete"
+
+#: prefs.js:215
+msgid "Save"
+msgstr "Uložit"
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr "Zrušit"
+
+#: prefs.js:235
+msgid "Revert to original name"
+msgstr "Vrátit na původní název"

--- a/po/de.po
+++ b/po/de.po
@@ -17,6 +17,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
 
-#: extension.js:47
+#: extension.js:94
 msgid "Restart To..."
 msgstr "Neustart zu ..."
+
+#: prefs.js:16
+msgid "General"
+msgstr "Allgemein"
+
+#: prefs.js:22
+msgid "Select Boot Entries to display"
+msgstr "Anzuzeigende Starteinträge auswählen"
+
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr "Klicken zum Ein-/Ausblenden. Ziehen zum Neuordnen. Namen anklicken zum Umbenennen."
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr "Tastenkombinationen"
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+"<b>J / K</b> : Ausgewählte Zeile nach unten / oben verschieben\n"
+"<b>Leertaste / Enter</b> : Sichtbarkeit umschalten\n"
+"<b>R / E / F2</b> : Eintrag umbenennen\n"
+"<b>Esc</b> : Bearbeitung abbrechen"
+
+#: prefs.js:48
+msgid "Understood"
+msgstr "Verstanden"
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr "Zum Umbenennen anklicken"
+
+#: prefs.js:215
+msgid "Save"
+msgstr "Speichern"
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: prefs.js:235
+msgid "Revert to original name"
+msgstr "Auf ursprünglichen Namen zurücksetzen"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the restartto@tiagoporsch.github.io package.
 # Jonathan Ravat <jonathan@ravat.eu>, 2026.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -18,18 +17,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#: extension.js:64
+#: extension.js:94
 msgid "Restart To..."
 msgstr "Redémarrer vers..."
 
-#: prefs.js:13
+#: prefs.js:16
 msgid "General"
 msgstr "Général"
 
-#: prefs.js:19
-msgid "Blacklist"
-msgstr "Liste noire"
+#: prefs.js:22
+msgid "Select Boot Entries to display"
+msgstr "Sélectionnez les entrées de démarrage à afficher"
 
-#: prefs.js:20
-msgid "Hide boot entries"
-msgstr "Masquer les entrées d'amorçage"
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr "Cliquez pour afficher/masquer. Glissez pour réorganiser. Cliquez sur un nom pour le renommer."
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr "Raccourcis clavier"
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+"<b>J / K</b> : Déplacer la ligne sélectionnée vers le bas / haut\n"
+"<b>Espace / Entrée</b> : Basculer la visibilité\n"
+"<b>R / E / F2</b> : Renommer l'entrée\n"
+"<b>Échap</b> : Annuler l'édition"
+
+#: prefs.js:48
+msgid "Understood"
+msgstr "J'ai compris"
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr "Cliquer pour renommer"
+
+#: prefs.js:215
+msgid "Save"
+msgstr "Enregistrer"
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr "Annuler"
+
+#: prefs.js:235
+msgid "Revert to original name"
+msgstr "Restaurer le nom d'origine"

--- a/po/hu.po
+++ b/po/hu.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the restartto@tiagoporsch.github.io package.
 # ViBE <vibe@protonmail.com>, 2024-2025.
 #
-
 msgid ""
 msgstr ""
 "Project-Id-Version: restartto@tiagoporsch.github.io\n"
@@ -19,18 +18,54 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Gtranslator 48.0\n"
 
-#: extension.js:64
+#: extension.js:94
 msgid "Restart To..."
 msgstr "Újraindítás..."
 
-#: prefs.js:13
+#: prefs.js:16
 msgid "General"
 msgstr "Általános"
 
-#: prefs.js:19
-msgid "Blacklist"
-msgstr "Feketelista"
+#: prefs.js:22
+msgid "Select Boot Entries to display"
+msgstr "Megjelenítendő rendszerindítási elemek kiválasztása"
 
-#: prefs.js:20
-msgid "Hide boot entries"
-msgstr "Elrejtendő rendszerindítási elemek kiválasztása"
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr "Kattintson a megjelenítéshez/elrejtéshez. Húzza az átrendezéshez. Kattintson a névre az átnevezéshez."
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr "Billentyűparancsok"
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+"<b>J / K</b> : Kijelölt sor mozgatása le / fel\n"
+"<b>Szóköz / Enter</b> : Láthatóság átváltása\n"
+"<b>R / E / F2</b> : Elem átnevezése\n"
+"<b>Esc</b> : Szerkesztés megszakítása"
+
+#: prefs.js:48
+msgid "Understood"
+msgstr "Megértettem"
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr "Kattintson az átnevezéshez"
+
+#: prefs.js:215
+msgid "Save"
+msgstr "Mentés"
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr "Mégse"
+
+#: prefs.js:235
+msgid "Revert to original name"
+msgstr "Visszaállítás az eredeti névre"

--- a/po/nl.po
+++ b/po/nl.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # Jop V. <jop@calory.nl>, 2025.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -18,18 +17,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
 
-#: extension.js:64
+#: extension.js:94
 msgid "Restart To..."
 msgstr "Herstarten naar..."
 
-#: prefs.js:13
+#: prefs.js:16
 msgid "General"
 msgstr "Algemeen"
 
-#: prefs.js:19
-msgid "Blacklist"
-msgstr "Zwarte lijst"
+#: prefs.js:22
+msgid "Select Boot Entries to display"
+msgstr "Selecteer weer te geven opstartitems"
 
-#: prefs.js:20
-msgid "Hide boot entries"
-msgstr "Verberg boot-entries"
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr "Klik om te tonen/verbergen. Sleep om te herschikken. Klik op een naam om te hernoemen."
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr "Sneltoetsen"
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+"<b>J / K</b> : Geselecteerde rij omlaag / omhoog verplaatsen\n"
+"<b>Spatie / Enter</b> : Zichtbaarheid schakelen\n"
+"<b>R / E / F2</b> : Item hernoemen\n"
+"<b>Esc</b> : Bewerken annuleren"
+
+#: prefs.js:48
+msgid "Understood"
+msgstr "Begrepen"
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr "Klik om te hernoemen"
+
+#: prefs.js:215
+msgid "Save"
+msgstr "Opslaan"
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr "Annuleren"
+
+#: prefs.js:235
+msgid "Revert to original name"
+msgstr "Herstellen naar oorspronkelijke naam"

--- a/po/pt.po
+++ b/po/pt.po
@@ -16,18 +16,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: extension.js:64
+#: extension.js:94
 msgid "Restart To..."
 msgstr "Reiniciar para..."
 
-#: prefs.js:13
+#: prefs.js:16
 msgid "General"
 msgstr "Geral"
 
-#: prefs.js:19
-msgid "Blacklist"
-msgstr "Lista negra"
+#: prefs.js:22
+msgid "Select Boot Entries to display"
+msgstr "Selecionar entradas de arranque a apresentar"
 
-#: prefs.js:20
-msgid "Hide boot entries"
-msgstr "Ocultar entradas de arranque"
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr "Clique para mostrar/ocultar. Arraste para reordenar. Clique nos nomes para mudar o nome."
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr "Atalhos de teclado"
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+"<b>J / K</b> : Mover a linha selecionada para baixo / cima\n"
+"<b>Espaço / Enter</b> : Alternar visibilidade\n"
+"<b>R / E / F2</b> : Mudar o nome da entrada\n"
+"<b>Esc</b> : Cancelar edição"
+
+#: prefs.js:48
+msgid "Understood"
+msgstr "Entendido"
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr "Clique para mudar o nome"
+
+#: prefs.js:215
+msgid "Save"
+msgstr "Guardar"
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: prefs.js:235
+msgid "Revert to original name"
+msgstr "Reverter para o nome original"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -16,18 +16,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: extension.js:64
+#: extension.js:94
 msgid "Restart To..."
 msgstr "Reiniciar para..."
 
-#: prefs.js:13
+#: prefs.js:16
 msgid "General"
 msgstr "Geral"
 
-#: prefs.js:19
-msgid "Blacklist"
-msgstr "Lista negra"
+#: prefs.js:22
+msgid "Select Boot Entries to display"
+msgstr "Selecionar entradas de inicialização para exibir"
 
-#: prefs.js:20
-msgid "Hide boot entries"
-msgstr "Ocultar entradas de inicialização"
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr "Clique para mostrar/ocultar. Arraste para reordenar. Clique nos nomes para renomear."
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr "Atalhos de teclado"
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+"<b>J / K</b> : Mover a linha selecionada para baixo / cima\n"
+"<b>Espaço / Enter</b> : Alternar visibilidade\n"
+"<b>R / E / F2</b> : Renomear entrada\n"
+"<b>Esc</b> : Cancelar edição"
+
+#: prefs.js:48
+msgid "Understood"
+msgstr "Entendido"
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr "Clique para renomear"
+
+#: prefs.js:215
+msgid "Save"
+msgstr "Salvar"
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: prefs.js:235
+msgid "Revert to original name"
+msgstr "Reverter para o nome original"

--- a/po/restartto@tiagoporsch.github.io.pot
+++ b/po/restartto@tiagoporsch.github.io.pot
@@ -17,18 +17,50 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:64
+#: extension.js:94
 msgid "Restart To..."
 msgstr ""
 
-#: prefs.js:13
+#: prefs.js:16
 msgid "General"
 msgstr ""
 
-#: prefs.js:19
-msgid "Blacklist"
+#: prefs.js:22
+msgid "Select Boot Entries to display"
 msgstr ""
 
-#: prefs.js:20
-msgid "Hide boot entries"
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr ""
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr ""
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+
+#: prefs.js:48
+msgid "Understood"
+msgstr ""
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr ""
+
+#: prefs.js:215
+msgid "Save"
+msgstr ""
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr ""
+
+#: prefs.js:235
+msgid "Revert to original name"
 msgstr ""

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the restartto@tiagoporsch.github.io package.
 # TechnoGuru123698741 <crasnolobovdanila@yandex.ru>, 2025.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: restartto@tiagoporsch.github.io\n"
@@ -17,18 +16,54 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:64
+#: extension.js:94
 msgid "Restart To..."
-msgstr "Перезапуск В..."
+msgstr "Перезапуск в..."
 
-#: prefs.js:13
+#: prefs.js:16
 msgid "General"
 msgstr "Общее"
 
-#: prefs.js:19
-msgid "Blacklist"
-msgstr "Чёрный список"
+#: prefs.js:22
+msgid "Select Boot Entries to display"
+msgstr "Выберите загрузочные записи для отображения"
 
-#: prefs.js:20
-msgid "Hide boot entries"
-msgstr "Скрыть загрузочные записи"
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr "Нажмите, чтобы показать/скрыть. Перетащите для изменения порядка. Нажмите на имя для переименования."
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr "Сочетания клавиш"
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+"<b>J / K</b> : Переместить выбранную строку вниз / вверх\n"
+"<b>Пробел / Enter</b> : Переключить видимость\n"
+"<b>R / E / F2</b> : Переименовать запись\n"
+"<b>Esc</b> : Отменить редактирование"
+
+#: prefs.js:48
+msgid "Understood"
+msgstr "Понятно"
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr "Нажмите для переименования"
+
+#: prefs.js:215
+msgid "Save"
+msgstr "Сохранить"
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr "Отмена"
+
+#: prefs.js:235
+msgid "Revert to original name"
+msgstr "Вернуть исходное имя"

--- a/po/sv.po
+++ b/po/sv.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
@@ -18,18 +17,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.9\n"
 
-#: extension.js:64
+#: extension.js:94
 msgid "Restart To..."
 msgstr "Starta om i..."
 
-#: prefs.js:13
+#: prefs.js:16
 msgid "General"
 msgstr "Allmänt"
 
-#: prefs.js:19
-msgid "Blacklist"
-msgstr "Svartlista"
+#: prefs.js:22
+msgid "Select Boot Entries to display"
+msgstr "Välj uppstartsposter att visa"
 
-#: prefs.js:20
-msgid "Hide boot entries"
-msgstr "Dölj uppstartsposter"
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr "Klicka för att visa/dölja. Dra för att ändra ordning. Klicka på namn för att byta namn."
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr "Kortkommandon"
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+"<b>J / K</b> : Flytta vald rad nedåt / uppåt\n"
+"<b>Mellanslag / Enter</b> : Växla synlighet\n"
+"<b>R / E / F2</b> : Byt namn på post\n"
+"<b>Esc</b> : Avbryt redigering"
+
+#: prefs.js:48
+msgid "Understood"
+msgstr "Förstått"
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr "Klicka för att byta namn"
+
+#: prefs.js:215
+msgid "Save"
+msgstr "Spara"
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: prefs.js:235
+msgid "Revert to original name"
+msgstr "Återställ till ursprungligt namn"

--- a/po/uk.po
+++ b/po/uk.po
@@ -17,18 +17,54 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: extension.js:64
+#: extension.js:94
 msgid "Restart To..."
 msgstr "Перезапустити до..."
 
-#: prefs.js:13
+#: prefs.js:16
 msgid "General"
 msgstr "Загальні"
 
-#: prefs.js:19
-msgid "Blacklist"
-msgstr "Список виключень"
+#: prefs.js:22
+msgid "Select Boot Entries to display"
+msgstr "Виберіть записи завантаження для відображення"
 
-#: prefs.js:20
-msgid "Hide boot entries"
-msgstr "Приховати записи завантаження"
+#: prefs.js:23
+msgid "Toggle to Show/Hide. Drag to reorder. Click names to rename."
+msgstr "Натисніть, щоб показати/приховати. Перетягніть для зміни порядку. Натисніть на назву для перейменування."
+
+#: prefs.js:29 prefs.js:37
+msgid "Keyboard Shortcuts"
+msgstr "Комбінації клавіш"
+
+#: prefs.js:38
+msgid ""
+"<b>J / K</b> : Move selected row down / up\n"
+"<b>Space / Enter</b> : Toggle visibility\n"
+"<b>R / E / F2</b> : Rename entry\n"
+"<b>Esc</b> : Cancel editing"
+msgstr ""
+"<b>J / K</b> : Перемістити вибраний рядок вниз / вгору\n"
+"<b>Пробіл / Enter</b> : Перемкнути видимість\n"
+"<b>R / E / F2</b> : Перейменувати запис\n"
+"<b>Esc</b> : Скасувати редагування"
+
+#: prefs.js:48
+msgid "Understood"
+msgstr "Зрозуміло"
+
+#: prefs.js:182
+msgid "Click to rename"
+msgstr "Натисніть для перейменування"
+
+#: prefs.js:215
+msgid "Save"
+msgstr "Зберегти"
+
+#: prefs.js:222
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: prefs.js:235
+msgid "Revert to original name"
+msgstr "Повернути початкову назву"

--- a/prefs.js
+++ b/prefs.js
@@ -1,14 +1,17 @@
 import Gio from 'gi://Gio';
 import Adw from 'gi://Adw';
 import GLib from 'gi://GLib';
+import Gtk from 'gi://Gtk';
+import Gdk from 'gi://Gdk';
+import GObject from 'gi://GObject';
 
 import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 import {getBootEntries} from './efi.js';
+import {migrateSettings} from './settingsmigration.js'
 
 export default class RestartToPreferences extends ExtensionPreferences {
     async fillPreferencesWindow(window) {
-        // Create a preferences page, with a single group
         const page = new Adw.PreferencesPage({
           title: _('General'),
           icon_name: 'system-restart-symbolic',
@@ -16,35 +19,435 @@ export default class RestartToPreferences extends ExtensionPreferences {
         window.add(page);
 
         const group = new Adw.PreferencesGroup({
-          title: _('Blacklist'),
-          description: _('Hide boot entries'),
+            title: _('Select Boot Entries to display'),
+            description: _('Toggle to Show/Hide. Drag to reorder. Click names to rename.'),
+        });
+
+        const helpBtn = new Gtk.Button({
+            icon_name: 'help-about',
+            valign: Gtk.Align.CENTER,
+            tooltip_text: _('Keyboard Shortcuts')
+        });
+        helpBtn.add_css_class('flat');
+
+        group.set_header_suffix(helpBtn);
+
+        helpBtn.connect('clicked', () => {
+            const dialog = new Adw.MessageDialog({
+                heading: _('Keyboard Shortcuts'),
+                body: _(
+                    '<b>J / K</b> : Move selected row down / up\n' +
+                    '<b>Space / Enter</b> : Toggle visibility\n' +
+                    '<b>R / E / F2</b> : Rename entry\n' +
+                    '<b>Esc</b> : Cancel editing'
+                ),
+                body_use_markup: true,
+            });
+            
+            // Add a simple close button to the dialog
+            dialog.add_response('close', _('Understood'));
+            dialog.set_default_response('close');
+            dialog.set_close_response('close');
+            
+            // Present the dialog over the main preferences window
+            dialog.present();
         });
         page.add(group);
 
-        // Settings binding
         const settings = this.getSettings();
         window._settings = settings;
 
-        // Available and blacklisted entries
-        const entries = Array.from((await getBootEntries()).values());
-        const blacklist = settings.get_strv('blacklist');
+        // Run settings Migration
+        await migrateSettings(settings);
 
-        // Create one settings row for each entry
-        for (const entry of ['UEFI'].concat(entries)) {
-            const row = new Adw.SwitchRow({
-                title: entry,
-                active: blacklist.includes(entry),
-            });
-            row.connect('notify::active', () => {
-                const updated = new Set(settings.get_strv('blacklist'));
-                if (row.active) {
-                    updated.add(entry);
-                } else {
-                    updated.delete(entry);
-                }
-                settings.set_strv('blacklist', Array.from(updated));
-            });
-            group.add(row);
+        // Custom CSS
+        const provider = new Gtk.CssProvider();
+        provider.load_from_data(`
+            .dim-row, .dim-row:hover, .dim-row:focus {opacity: 0.40;}
+            .dim-row .suggested-action {opacity: 0.40;}
+            .dim-row .flat {opacity: 0.40;}
+
+            row:focus-visible {
+                background-color: @accent_bg_color;
+                color: @accent_fg_color;
+            }
+            row:focus-visible .dim-label {
+                color: alpha(@accent_fg_color, 0.7);
+            }
+        `, -1);
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        );
+
+        this._draggedEntryId = null;
+
+        const listBox = new Gtk.ListBox();
+        listBox.add_css_class('boxed-list');
+        listBox.set_selection_mode(Gtk.SelectionMode.NONE);
+        listBox.set_activate_on_single_click(false);
+        group.add(listBox);
+        listBox.set_focusable(true);
+
+        const bootEntries = await getBootEntries();
+        const hiddenEntries = settings.get_strv('hidden-entries');
+        const savedOrder = settings.get_strv('order');
+
+        let customNames = {};
+        try {
+            customNames = JSON.parse(settings.get_string('custom-names') || '{}');
+        } catch (e) {
+            customNames = {};
         }
+
+        const items = [{ id: 'UEFI', defaultName: 'UEFI' }];
+        for (const [id, name] of bootEntries.entries()) {
+            items.push({ id: id, defaultName: name });
+        }
+
+        // Sort items initially based on saved order
+        items.sort((a, b) => {
+            let idxA = savedOrder.indexOf(a.id);
+            let idxB = savedOrder.indexOf(b.id);
+            if (idxA === -1) idxA = 999;
+            if (idxB === -1) idxB = 999;
+            return idxA - idxB;
+        });
+
+        let currentOrder = items.map(item => item.id);
+
+        listBox.set_sort_func((rowA, rowB) => {
+            if (!rowA._entryId || !rowB._entryId) return 0;
+            const idxA = currentOrder.indexOf(rowA._entryId);
+            const idxB = currentOrder.indexOf(rowB._entryId);
+            return idxA - idxB;
+        });
+
+        for (const item of items) {
+            const entryId = item.id;
+            const defaultName = item.defaultName;
+            const hasCustomName = !!customNames[entryId];
+            const displayName = hasCustomName ? customNames[entryId] : defaultName;
+            const isHidden = hiddenEntries.includes(entryId);
+
+            const row = new Adw.PreferencesRow();
+            row._entryId = entryId;
+            row._isEditing = false;
+            row.set_selectable(false);
+            row.set_activatable(false);
+            row.set_focusable(true);
+            row.set_focus_on_click(false);
+            
+            if (isHidden) {
+                row.add_css_class('dim-row');
+            }
+
+            const mainBox = new Gtk.Box({
+                orientation: Gtk.Orientation.HORIZONTAL,
+                spacing: 12,
+                margin_start: 16,
+                margin_end: 16,
+                margin_top: 4,
+                margin_bottom: 4,
+                valign: Gtk.Align.CENTER
+            });
+            mainBox.set_size_request(-1, 46);
+            row.set_child(mainBox);
+
+            // Drag Handle Icon
+            const handleImg = new Gtk.Image({
+                icon_name: 'list-drag-handle-symbolic',
+                valign: Gtk.Align.CENTER
+            });
+            handleImg.set_focusable(false);
+            handleImg.add_css_class('dim-label');
+            mainBox.append(handleImg);
+
+            // Title container
+            const titleContainer = new Gtk.Box({
+                orientation: Gtk.Orientation.HORIZONTAL,
+                spacing: 6,
+                valign: Gtk.Align.CENTER,
+                hexpand: true
+            });
+            mainBox.append(titleContainer);
+
+            // Text Display Mode
+            const titleBox = new Gtk.Box({
+                orientation: Gtk.Orientation.HORIZONTAL,
+                spacing: 6,
+                valign: Gtk.Align.CENTER,
+                tooltip_text: _("Click to rename")
+            });
+            
+            const label = new Gtk.Label({
+                label: displayName,
+                xalign: 0,
+                valign: Gtk.Align.CENTER
+            });
+            titleBox.append(label);
+            label.set_focusable(false);
+
+            const pencilImg = new Gtk.Image({
+                icon_name: 'document-edit-symbolic',
+                visible: hasCustomName,
+                valign: Gtk.Align.CENTER
+            });
+            pencilImg.add_css_class('dim-label');
+            titleBox.append(pencilImg);
+            titleContainer.append(titleBox);
+            pencilImg.set_focusable(false);
+
+            // Text Input/Edit Mode
+            const editEntry = new Gtk.Entry({
+                text: displayName,
+                visible: false,
+                hexpand: true,
+                valign: Gtk.Align.CENTER
+            });
+
+            const saveBtn = new Gtk.Button({
+                icon_name: 'object-select-symbolic',
+                visible: false,
+                valign: Gtk.Align.CENTER,
+                tooltip_text: _('Save')
+            });
+            saveBtn.add_css_class('suggested-action');
+
+            const cancelBtn = new Gtk.Button({
+                icon_name: 'window-close-symbolic',
+                visible: false,
+                valign: Gtk.Align.CENTER,
+                tooltip_text: _('Cancel')
+            });
+            cancelBtn.add_css_class('destructive-action');
+
+            titleContainer.append(editEntry);
+            titleContainer.append(saveBtn);
+            titleContainer.append(cancelBtn);
+
+            // Suffix Controls
+            const resetBtn = new Gtk.Button({
+                icon_name: 'view-refresh-symbolic',
+                visible: hasCustomName,
+                valign: Gtk.Align.CENTER,
+                tooltip_text: _("Revert to original name")
+            });
+            resetBtn.add_css_class('flat');
+            resetBtn.set_focusable(false);
+
+            const switchWidget = new Gtk.Switch({
+                active: !isHidden,
+                valign: Gtk.Align.CENTER
+            });
+            row._switchWidget = switchWidget;
+            switchWidget.set_focusable(false);
+            
+            mainBox.append(resetBtn);
+            mainBox.append(switchWidget);
+
+            // DRAG CONTROLLER
+            const dragSource = new Gtk.DragSource({ actions: Gdk.DragAction.MOVE });
+            dragSource.connect('prepare', (source, x, y) => {
+                return Gdk.ContentProvider.new_for_value(entryId);
+            });
+            
+            dragSource.connect('drag-begin', (source, drag) => {
+                this._draggedEntryId = entryId;
+
+                // Snap full graphical picture layout to display under cursor
+                const paintable = Gtk.WidgetPaintable.new(row);
+                Gtk.DragIcon.set_from_paintable(drag, paintable, 0, 0);
+            });
+
+            dragSource.connect('drag-end', () => {
+                this._draggedEntryId = null;
+                settings.set_strv('order', currentOrder);
+            });
+            row.add_controller(dragSource);
+
+            // DROP CONTROLLER
+            const dropTarget = Gtk.DropTarget.new(GObject.TYPE_STRING, Gdk.DragAction.MOVE);
+            dropTarget.connect('enter', (target, x, y) => {
+                const draggedId = this._draggedEntryId;
+                if (!draggedId || draggedId === entryId) return Gdk.DragAction.NONE;
+
+                const draggedIdx = currentOrder.indexOf(draggedId);
+                const targetIdx = currentOrder.indexOf(entryId);
+
+                if (draggedIdx !== -1 && targetIdx !== -1) {
+                    currentOrder.splice(draggedIdx, 1);
+                    currentOrder.splice(targetIdx, 0, draggedId);
+                    
+                    listBox.invalidate_sort();
+                }
+                return Gdk.DragAction.MOVE;
+            });
+
+            dropTarget.connect('drop', () => {
+                return true;
+            });
+            row.add_controller(dropTarget);
+
+            // Rename actions
+            const clickGesture = new Gtk.GestureClick();
+            clickGesture.connect('released', () => {
+                row._startRename();
+            });
+            titleBox.add_controller(clickGesture);
+
+            row._startRename = () => {
+                row._isEditing = true;
+                titleBox.set_visible(false);
+                editEntry.set_text(label.get_text());
+                editEntry.set_visible(true);
+                saveBtn.set_visible(true);
+                cancelBtn.set_visible(true);
+                editEntry.grab_focus();
+            };
+
+            const saveChanges = () => {
+                const newName = editEntry.get_text().trim();
+                let currentCustomNames = {};
+                try {
+                    currentCustomNames = JSON.parse(settings.get_string('custom-names') || '{}');
+                } catch (e) {}
+
+                if (newName && newName !== defaultName) {
+                    currentCustomNames[entryId] = newName;
+                    label.set_text(newName);
+                    pencilImg.set_visible(true);
+                    resetBtn.set_visible(true);
+                } else {
+                    delete currentCustomNames[entryId];
+                    label.set_text(defaultName);
+                    pencilImg.set_visible(false);
+                    resetBtn.set_visible(false);
+                }
+
+                settings.set_string('custom-names', JSON.stringify(currentCustomNames));
+                exitEditMode();
+            };
+
+            const cancelEdit = () => {
+                editEntry.set_text(label.get_text());
+                exitEditMode();
+            };
+
+            const exitEditMode = () => {
+                row._isEditing = false;
+                editEntry.set_visible(false);
+                saveBtn.set_visible(false);
+                cancelBtn.set_visible(false);
+                titleBox.set_visible(true);
+                row.grab_focus();
+            };
+
+            saveBtn.connect('clicked', saveChanges);
+            cancelBtn.connect('clicked', cancelEdit);
+            editEntry.connect('activate', saveChanges);
+
+            // Escape key → cancel
+            const keyController = new Gtk.EventControllerKey();
+            keyController.connect('key-pressed', (ctrl, keyval) => {
+                if (keyval === Gdk.KEY_Escape) {
+                    cancelEdit();
+                    return true;
+                }
+                return false;
+            });
+            editEntry.add_controller(keyController);
+
+            // Click-away / focus lost cancels
+            const focusController = new Gtk.EventControllerFocus();
+            focusController.connect('leave', () => {
+                if (editEntry.get_visible()) {
+                    cancelEdit();
+                }
+            });
+            editEntry.add_controller(focusController);
+
+            // Action: Revert Name Reset Button
+            resetBtn.connect('clicked', () => {
+                let currentCustomNames = {};
+                try {
+                    currentCustomNames = JSON.parse(settings.get_string('custom-names') || '{}');
+                } catch (e) {}
+
+                delete currentCustomNames[entryId];
+                settings.set_string('custom-names', JSON.stringify(currentCustomNames));
+
+                label.set_text(defaultName);
+                editEntry.set_text(defaultName);
+                pencilImg.set_visible(false);
+                resetBtn.set_visible(false);
+            });
+
+            // Toggle Visibility
+            switchWidget.connect('notify::active', () => {
+                const updated = new Set(settings.get_strv('hidden-entries'));
+                if (switchWidget.active) {
+                    updated.delete(entryId);
+                    row.remove_css_class('dim-row');
+                } else {
+                    updated.add(entryId);
+                    row.add_css_class('dim-row');
+                }
+                settings.set_strv('hidden-entries', Array.from(updated));
+            });
+
+            listBox.append(row);
+        }
+        
+        const _moveRow = (focused, direction) => {
+            const entryId = focused._entryId;
+            const idx = currentOrder.indexOf(entryId);
+            const newIdx = idx + direction;
+
+            if (newIdx >= 0 && newIdx < currentOrder.length) {
+                const temp = currentOrder[idx];
+                currentOrder[idx] = currentOrder[newIdx];
+                currentOrder[newIdx] = temp;
+                
+                listBox.invalidate_sort();
+                
+                settings.set_strv('order', currentOrder);
+
+                focused.grab_focus();
+            }
+        };
+        
+        const keyController = new Gtk.EventControllerKey();
+        keyController.connect('key-pressed', (ctrl, keyval) => {
+            const focused = listBox.get_focus_child();
+
+            if (!focused || !focused._entryId) return false;
+            
+            if (focused._isEditing) return false;
+
+            if (keyval === Gdk.KEY_r || keyval === Gdk.KEY_e || keyval === Gdk.KEY_F2) {
+                focused._startRename();
+                return true;
+            }
+
+            if (keyval === Gdk.KEY_space || keyval === Gdk.KEY_Return) {
+                focused._switchWidget.set_active(!focused._switchWidget.get_active());
+                return true;
+            }
+
+            if (keyval === Gdk.KEY_j) {  // Down
+                _moveRow(focused, 1);
+                return true;
+            }
+            if (keyval === Gdk.KEY_k) {  // Up
+                _moveRow(focused, -1);
+                return true;
+            }
+
+            return false;
+        });
+
+        listBox.add_controller(keyController);
     }
 }

--- a/schemas/org.gnome.shell.extensions.restartto.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.restartto.gschema.xml
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
   <schema id="org.gnome.shell.extensions.restartto" path="/org/gnome/shell/extensions/restartto/">
+    
+    <key name="hidden-entries" type="as">
+      <default>[]</default>
+      <summary>Hidden Entries</summary>
+      <description>Which entries to hide from the `Restart to...` menu</description>
+    </key>
+    <key name="custom-names" type="s">
+      <default>'{}'</default>
+      <summary>Custom Names Mapping</summary>
+      <description>JSON string mapping boot entry IDs to customized display names</description>
+    </key>
+    <key name="order" type="as">
+      <default>[]</default>
+      <summary>Entries Order</summary>
+      <description>The custom order sequence of boot entry IDs</description>
+    </key>
+    
+    <!-- DEPRECATED KEY (Kept for migration) -->
     <key name="blacklist" type="as">
       <default>[]</default>
-      <summary>Blacklist</summary>
-      <description>Which entries to hide from the `Restart to...` menu</description>
+      <summary>DEPRECATED: Blacklist</summary>
+      <description>Legacy key for hiding items. Use hidden-entries instead.</description>
     </key>
   </schema>
 </schemalist>

--- a/settingsmigration.js
+++ b/settingsmigration.js
@@ -1,0 +1,72 @@
+import { getBootEntries } from './efi.js';
+const DEBUG = false;
+
+export async function migrateSettings(settings) {
+    if (DEBUG) console.log('[RestartTo-SettingsMigration] Checking if settings migration is needed...');
+
+    if (!settings.settings_schema.has_key('blacklist')) {
+        console.warn('[RestartTo-SettingsMigration] WARNING: blacklist key missing from schema! Migration aborted.');
+        return;
+    }
+
+    const blacklist = settings.get_strv('blacklist');
+    if (blacklist.length === 0) {
+        if (DEBUG) console.log('[RestartTo-SettingsMigration] Blacklist is empty. No migration needed.');
+        return;
+    }
+
+    if (DEBUG) console.log(`[RestartTo-SettingsMigration] Found old blacklist: ${JSON.stringify(blacklist)}`);
+    const hiddenEntries = settings.get_strv('hidden-entries');
+    if (hiddenEntries.length !== 0) {
+        if (DEBUG) console.log('[RestartTo-SettingsMigration] hidden-entries already populated. Skipping migration.');
+        return;
+    }
+
+    if (DEBUG) console.log('[RestartTo-SettingsMigration] Translating old names to EFI IDs...');
+    const bootEntries = await getBootEntries();
+
+    // Build a name → array of IDs lookup table
+    const nameToIds = new Map();
+    for (const [id, name] of bootEntries.entries()) {
+        const trimmed = name.trim();
+        if (nameToIds.has(trimmed)) {
+            nameToIds.get(trimmed).push(id);
+        } else {
+            nameToIds.set(trimmed, [id]);
+        }
+    }
+
+    // Log any duplicate names found
+    for (const [name, ids] of nameToIds.entries()) {
+        if (ids.length > 1) {
+            console.log(`[RestartTo-SettingsMigration] ⚠️  Duplicate name detected: "${name}" has ${ids.length} entries: ${JSON.stringify(ids)}`);
+        }
+    }
+
+    const translatedEntries = [];
+    for (const oldName of blacklist) {
+        if (oldName === 'UEFI') {
+            translatedEntries.push('UEFI');
+            continue;
+        }
+
+        const trimmed = oldName.trim();
+        const ids = nameToIds.get(trimmed);
+
+        if (ids) {
+            if (DEBUG) console.log(`[RestartTo-SettingsMigration] Mapped "${oldName}" -> ${JSON.stringify(ids)}`);
+            translatedEntries.push(...ids);
+        } else {
+            if (DEBUG) console.log(`[RestartTo-SettingsMigration] Could not map "${oldName}" (Not found in EFI). Keeping as string.`);
+            translatedEntries.push(trimmed);
+        }
+    }
+
+    // Eventually Deduplicate
+    const uniqueTranslated = [...new Set(translatedEntries)];
+    settings.set_strv('hidden-entries', uniqueTranslated);
+    if (DEBUG) console.log(`[RestartTo-SettingsMigration] Migration successful! New hidden-entries: ${JSON.stringify(uniqueTranslated)}`);
+
+    // And clear old blacklist
+    settings.set_strv('blacklist', []);
+}


### PR DESCRIPTION
### Hey everyone! 👋 

I am a Windows user migrating to Linux and this extension has been incredibly useful for dual booting, especially since it comes pre-packaged with Bazzite. As someone who went through the pains of migration, my main motivation for this PR was to make that transition as smooth and welcoming as possible for other Windows users. 

To help with that, I've overhauled the preferences UI to make managing boot entries more intuitive, ergonomic, and accessible.



> ### PR Details & Disclosures:
> - **Resolves Issues:**
>   - #32 
>   - #33 
>   - #34 
>   - #35 
> - **Co-authored by AI** (Google Gemini 3.1 Pro Preview)
> - **Tested on:** RestartTo v15, v16. Bazzite GNOME 49

‎   

# What Changed
*Since this is a pretty substantial update to the UI/UX, I recorded a quick video demonstrating the Before & After rather than taking a dozen screenshots.* 

https://github.com/user-attachments/assets/522aa411-4b80-48c0-b9f4-e5c1c99c11bc

### ✨  **Features**  
- Added the ability to rename boot entries (Click the name to edit, or use shortcuts: `F2`, `R`ename, or `E`dit).
- Added the ability to reorder boot entries via Drag and Drop, or via keyboard shortcuts (Vim style `J` and `K`).
- Added comprehensive keyboard navigation support to increase accessibility (`Tab` to cycle entries, or `Up`/`Down` arrows to select).

### 👍  **Improvements**  
- Switched the visibility logic from a blacklist to a more intuitive whitelist. 
  - Toggling an entry ON now means it is Visible.
  - Toggling an entry OFF now hides it and even greys it out in the UI for better readability. 
  - _Note 1: All entries are ON by default so the out-of-the-box experience remains friendly._
  - _Note 2: This PR comes with the migration code to seamlessly transition pre-existing users' configurations upon load._
- Fixed the issue where multiple entries with the exact same name (e.g., two "Windows Boot Manager"s) would share settings. Entries are now internally mapped by their unique UEFI number (e.g., 0003) instead of their display name.
- Updated all language translations to reflect the new UI and preferences text. 
  - _Caveat: I only speak English and French, so I had to rely on tools for the other languages. Native speakers might need to tweak them for idiomatic accuracy in the future, but I believe the UX improvements are worth the cost._

‎   
‎   

# Comparison


## Preferences Window
<img width="700" height="621" alt="Screenshot From 2026-05-23 15-01-11" src="https://github.com/user-attachments/assets/29e02c9a-5743-4b98-a3fe-c64ddd12bf92" />

### Original
_See first half of the video._
- You had to toggle an entry "ON" to Disable it from showing in the menu (counterintuitive).
- Static list; could not reorder or rename anything.
- Identically named entries are bugged.

### Improved  
_See second half of the video._  
- **Visuals:** Entries toggled off are now greyed out, clearly showing they won't appear in the menu.
- **Ergonomics:** You can easily drag and drop items to organize your boot menu exactly how you want it. 
- **Customization:** Clicking an entry's name lets you type a custom name, keeping your quick toggles menu clean and personalized.
‎   
‎   

## Keyboard Navigation & Accessibility
<img width="700" height="621" alt="Screenshot From 2026-05-23 15-01-22" src="https://github.com/user-attachments/assets/5463cfba-62f8-461c-ae91-631522c3c59a" />

### Original
_See first half of the video._
- Relied entirely on mouse clicks to manage entries.

### Improved  
_See second half of the video._  
- You can now navigate the entire list using the keyboard. 
- Pressing `Tab` cycles cleanly through the entries themselves (isolated from the rest of the UI) and neatly unselects with a timeout.
- Or use `Up` and `Down` arrows to select different entries.
- Use `R`, `E`, or `F2` to rename the selected entry.
- And `J` or `K` to move entries up and down the list without ever touching the mouse.
‎   
‎   

_Thanks a lot for maintaining this extension. I use it every week; it has been a lifesaver during my migration!_
_Happy to make any changes or answer questions if anything needs tweaking._
### 🌟